### PR TITLE
Make GLFW include gl3.h instead of gl.h

### DIFF
--- a/src/jpeg_gpu.c
+++ b/src/jpeg_gpu.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <jpeglib.h>
 #include <getopt.h>
+#define GLFW_INCLUDE_GLCOREARB
 #define GL_GLEXT_PROTOTYPES
 #include <GLFW/glfw3.h>
 #include "jpeg_wrap.h"


### PR DESCRIPTION
This is needed to compile on OS X.
